### PR TITLE
Add option to serialize parameters

### DIFF
--- a/lib/logstasher.rb
+++ b/lib/logstasher.rb
@@ -5,6 +5,7 @@ module LogStasher
     attr_reader :append_fields_callback
     attr_writer :enabled
     attr_writer :include_parameters
+    attr_writer :serialize_parameters
     attr_writer :silence_standard_logging
 
     def append_fields(&block)
@@ -25,6 +26,14 @@ module LogStasher
       end
 
       @include_parameters
+    end
+
+    def serialize_parameters?
+      if @serialize_parameters.nil?
+        @serialize_parameters = true
+      end
+
+      @serialize_parameters
     end
 
     def initialize_logger(device = $stdout, level = ::Logger::INFO)

--- a/lib/logstasher/log_subscriber.rb
+++ b/lib/logstasher/log_subscriber.rb
@@ -84,7 +84,13 @@ module LogStasher
 
     def extract_parameters(payload)
       if LogStasher.include_parameters?
-        { :params => JSON.generate(payload[:params].except(*INTERNAL_PARAMS)) }
+        external_params = payload[:params].except(*INTERNAL_PARAMS)
+
+        if LogStasher.serialize_parameters?
+          { :params => JSON.generate(external_params) }
+        else
+          { :params => external_params }
+        end
       else
         {}
       end

--- a/lib/logstasher/railtie.rb
+++ b/lib/logstasher/railtie.rb
@@ -3,6 +3,7 @@ module LogStasher
     config.logstasher = ::ActiveSupport::OrderedOptions.new
     config.logstasher.enabled = false
     config.logstasher.include_parameters = true
+    config.logstasher.serialize_parameters = true
     config.logstasher.silence_standard_logging = false
     config.logstasher.logger = nil
     config.logstasher.log_level = ::Logger::INFO
@@ -12,6 +13,7 @@ module LogStasher
 
       ::LogStasher.enabled                  = options.enabled
       ::LogStasher.include_parameters       = options.include_parameters
+      ::LogStasher.serialize_parameters     = options.serialize_parameters
       ::LogStasher.silence_standard_logging = options.silence_standard_logging
       ::LogStasher.logger                   = options.logger || default_logger
       ::LogStasher.logger.level             = options.log_level

--- a/spec/lib/logstasher/device/redis_spec.rb
+++ b/spec/lib/logstasher/device/redis_spec.rb
@@ -13,28 +13,28 @@ describe LogStasher::Device::Redis do
 
   it 'has default options' do
     device = LogStasher::Device::Redis.new
-    device.options.should eq(default_options)
+    expect(device.options).to eq(default_options)
   end
 
   it 'creates a redis instance' do
-    ::Redis.should_receive(:new).with({})
+    expect(::Redis).to receive(:new).with({})
     LogStasher::Device::Redis.new()
   end
 
   it 'assumes unknown options are for redis' do
-    ::Redis.should_receive(:new).with(hash_including('db' => '0'))
+    expect(::Redis).to receive(:new).with(hash_including('db' => '0'))
     device = LogStasher::Device::Redis.new(db: '0')
-    device.redis_options.should eq('db' => '0')
+    expect(device.redis_options).to eq('db' => '0')
   end
 
   it 'has a key' do
     device = LogStasher::Device::Redis.new(key: 'the_key')
-    device.key.should eq 'the_key'
+    expect(device.key).to eq 'the_key'
   end
 
   it 'has a data_type' do
     device = LogStasher::Device::Redis.new(data_type: 'channel')
-    device.data_type.should eq 'channel'
+    expect(device.data_type).to eq 'channel'
   end
 
   it 'does not allow unsupported data types' do
@@ -45,13 +45,13 @@ describe LogStasher::Device::Redis do
 
   it 'quits the redis connection on #close' do
     device = LogStasher::Device::Redis.new
-    device.redis.should_receive(:quit)
+    expect(device.redis).to receive(:quit)
     device.close
   end
 
   it 'works as a logger device' do
     device = LogStasher::Device::Redis.new
-    device.should_receive(:write).with('blargh')
+    expect(device).to receive(:write).with('blargh')
     logger = Logger.new(device)
     logger << 'blargh'
   end
@@ -59,19 +59,19 @@ describe LogStasher::Device::Redis do
   describe '#write' do
     it "rpushes logs onto a list" do
       device = LogStasher::Device::Redis.new(data_type: 'list')
-      device.redis.should_receive(:rpush).with('logstash', 'the log')
+      expect(device.redis).to receive(:rpush).with('logstash', 'the log')
       device.write('the log')
     end
 
     it "rpushes logs onto a custom key" do
       device = LogStasher::Device::Redis.new(data_type: 'list', key: 'custom')
-      device.redis.should_receive(:rpush).with('custom', 'the log')
+      expect(device.redis).to receive(:rpush).with('custom', 'the log')
       device.write('the log')
     end
 
     it "publishes logs onto a channel" do
       device = LogStasher::Device::Redis.new(data_type: 'channel', key: 'custom')
-      device.redis.should_receive(:publish).with('custom', 'the log')
+      expect(device.redis).to receive(:publish).with('custom', 'the log')
       device.write('the log')
     end
   end

--- a/spec/lib/logstasher/device/syslog_spec.rb
+++ b/spec/lib/logstasher/device/syslog_spec.rb
@@ -11,7 +11,7 @@ describe LogStasher::Device::Syslog do
     'flags'    => ::Syslog::LOG_PID | ::Syslog::LOG_CONS
   }}
 
-  before { ::Syslog.stub(:log) }
+  before { allow(::Syslog).to receive(:log) }
 
   around do |example|
     ::Syslog.close if ::Syslog.opened?
@@ -21,72 +21,72 @@ describe LogStasher::Device::Syslog do
 
   it 'has default options' do
     device = LogStasher::Device::Syslog.new
-    device.options.should eq(default_options)
+    expect(device.options).to eq(default_options)
   end
 
   it 'has an identity' do
     device = LogStasher::Device::Syslog.new(:identity => 'rspec')
-    device.identity.should eq 'rspec'
+    expect(device.identity).to eq 'rspec'
   end
 
   it 'has a facility' do
     device = LogStasher::Device::Syslog.new(:facility => ::Syslog::LOG_USER)
-    device.facility.should eq ::Syslog::LOG_USER
+    expect(device.facility).to eq ::Syslog::LOG_USER
   end
 
   it 'accepts facility as a string' do
     device = LogStasher::Device::Syslog.new(:facility => 'LOG_LOCAL7')
-    device.facility.should eq ::Syslog::LOG_LOCAL7
+    expect(device.facility).to eq ::Syslog::LOG_LOCAL7
   end
 
   it 'has a priority' do
     device = LogStasher::Device::Syslog.new(:priority => ::Syslog::LOG_CRIT)
-    device.priority.should eq ::Syslog::LOG_CRIT
+    expect(device.priority).to eq ::Syslog::LOG_CRIT
   end
 
   it 'accepts priority as a string' do
     device = LogStasher::Device::Syslog.new(:priority => 'LOG_AUTH')
-    device.priority.should eq ::Syslog::LOG_AUTH
+    expect(device.priority).to eq ::Syslog::LOG_AUTH
   end
 
   it 'has flags' do
     device = LogStasher::Device::Syslog.new(:flags => ::Syslog::LOG_NOWAIT)
-    device.flags.should eq ::Syslog::LOG_NOWAIT
+    expect(device.flags).to eq ::Syslog::LOG_NOWAIT
   end
 
   it 'accepts flags as a string' do
     device = LogStasher::Device::Syslog.new(:flags => 'LOG_NDELAY')
-    device.flags.should eq ::Syslog::LOG_NDELAY
+    expect(device.flags).to eq ::Syslog::LOG_NDELAY
   end
 
   it 'accepts flags as an array of strings' do
     device = LogStasher::Device::Syslog.new(:flags => ['LOG_NOWAIT', 'LOG_ODELAY'])
-    device.flags.should eq(::Syslog::LOG_NOWAIT | ::Syslog::LOG_ODELAY)
+    expect(device.flags).to eq(::Syslog::LOG_NOWAIT | ::Syslog::LOG_ODELAY)
   end
 
   describe '#write' do
     subject { LogStasher::Device::Syslog.new }
 
     it 'opens syslog when syslog is closed' do
-      ::Syslog.should_receive(:open).with(subject.identity, subject.flags, subject.facility)
+      expect(::Syslog).to receive(:open).with(subject.identity, subject.flags, subject.facility)
       subject.write('a log')
     end
 
     it 'does not re-open syslog when its config is in sync' do
       ::Syslog.open(subject.identity, subject.flags, subject.facility)
-      ::Syslog.should_not_receive(:open)
-      ::Syslog.should_not_receive(:reopen)
+      expect(::Syslog).not_to receive(:open)
+      expect(::Syslog).not_to receive(:reopen)
       subject.write('a log')
     end
 
     it 're-opens syslog when its config is out of sync' do
       ::Syslog.open('temp', ::Syslog::LOG_NDELAY, ::Syslog::LOG_AUTH)
-      ::Syslog.should_receive(:reopen).with(subject.identity, subject.flags, subject.facility)
+      expect(::Syslog).to receive(:reopen).with(subject.identity, subject.flags, subject.facility)
       subject.write('a log')
     end
 
     it 'writes the log to syslog' do
-      ::Syslog.should_receive(:log).with(subject.facility, 'a log')
+      expect(::Syslog).to receive(:log).with(subject.facility, 'a log')
       subject.write('a log')
     end
 
@@ -103,17 +103,17 @@ describe LogStasher::Device::Syslog do
 
     it 'closes the device' do
       subject.close
-      subject.should be_closed
+      expect(subject).to be_closed
     end
 
     it 'closes syslog when syslog is open' do
       ::Syslog.open(subject.identity, subject.flags, subject.facility)
-      ::Syslog.should_receive(:close)
+      expect(::Syslog).to receive(:close)
       subject.close
     end
 
     it 'does not close syslog if it is already closed' do
-      ::Syslog.should_not_receive(:close)
+      expect(::Syslog).not_to receive(:close)
       subject.close
     end
   end

--- a/spec/lib/logstasher/device_spec.rb
+++ b/spec/lib/logstasher/device_spec.rb
@@ -13,7 +13,7 @@ describe LogStasher::Device do
     end
 
     it "forwards configuration options to the device" do
-      ::LogStasher::Device::Redis.should_receive(:new).with(
+      expect(::LogStasher::Device::Redis).to receive(:new).with(
         'options' => "other", 'than' => "type"
       )
       ::LogStasher::Device.factory(
@@ -22,7 +22,7 @@ describe LogStasher::Device do
     end
 
     it "accepts symbolized configuration keys" do
-      ::LogStasher::Device::Redis.should_receive(:new).with(
+      expect(::LogStasher::Device::Redis).to receive(:new).with(
         'options' => "other", 'than' => "type"
       )
       ::LogStasher::Device.factory(
@@ -31,19 +31,21 @@ describe LogStasher::Device do
     end
 
     it "can create redis devices" do
-      ::LogStasher::Device.should_receive(:require)
-                          .with("logstasher/device/redis")
+      expect(
+        ::LogStasher::Device
+      ).to receive(:require).with("logstasher/device/redis")
 
       device = ::LogStasher::Device.factory(:type => "redis")
-      device.should be_a_kind_of(::LogStasher::Device::Redis)
+      expect(device).to be_a_kind_of(::LogStasher::Device::Redis)
     end
 
     it "can create syslog devices" do
-      ::LogStasher::Device.should_receive(:require)
-                          .with("logstasher/device/syslog")
+      expect(
+        ::LogStasher::Device
+       ).to receive(:require).with("logstasher/device/syslog")
 
       device = ::LogStasher::Device.factory(:type => "syslog")
-      device.should be_a_kind_of(::LogStasher::Device::Syslog)
+      expect(device).to be_a_kind_of(::LogStasher::Device::Syslog)
     end
 
     it "fails to create unknown devices" do

--- a/spec/lib/logstasher/railtie_spec.rb
+++ b/spec/lib/logstasher/railtie_spec.rb
@@ -26,17 +26,19 @@ describe ::LogStasher::Railtie do
     end
 
     it 'should configure LogStasher' do
-      config.logger                   =  ::Logger.new('/dev/null')
+      config.logger                   = ::Logger.new('/dev/null')
       config.log_level                = "log_level"
       config.enabled                  = "enabled"
       config.include_parameters       = "include_parameters"
+      config.serialize_parameters     = "serialize_parameters"
       config.silence_standard_logging = "silence_standard_logging"
 
-      ::LogStasher.should_receive(:enabled=).with("enabled")
-      ::LogStasher.should_receive(:include_parameters=).with("include_parameters")
-      ::LogStasher.should_receive(:silence_standard_logging=).with("silence_standard_logging")
-      ::LogStasher.should_receive(:logger=).with(config.logger).and_call_original
-      config.logger.should_receive(:level=).with("log_level")
+      expect(::LogStasher).to receive(:enabled=).with("enabled")
+      expect(::LogStasher).to receive(:include_parameters=).with("include_parameters")
+      expect(::LogStasher).to receive(:serialize_parameters=).with("serialize_parameters")
+      expect(::LogStasher).to receive(:silence_standard_logging=).with("silence_standard_logging")
+      expect(::LogStasher).to receive(:logger=).with(config.logger).and_call_original
+      expect(config.logger).to receive(:level=).with("log_level")
 
       subject.run
     end
@@ -51,19 +53,19 @@ describe ::LogStasher::Railtie do
 
     context 'when logstasher is disabled' do
       it 'does nothing' do
-        ::ActiveSupport.should_not_receive(:on_load)
+        expect(::ActiveSupport).not_to receive(:on_load)
 
         subject.run
       end
     end
 
     context 'when logstasher is enabled' do
-      before { ::LogStasher.stub(:enabled?) { true } }
+      before { allow(::LogStasher).to receive(:enabled?) { true } }
 
       it 'should load LogStasher into ActionController' do
-        ::ActionController.should_receive(:require).with('logstasher/log_subscriber')
-        ::ActionController.should_receive(:require).with('logstasher/context_wrapper')
-        ::ActionController.should_receive(:include).with(::LogStasher::ContextWrapper)
+        expect(::ActionController).to receive(:require).with('logstasher/log_subscriber')
+        expect(::ActionController).to receive(:require).with('logstasher/context_wrapper')
+        expect(::ActionController).to receive(:include).with(::LogStasher::ContextWrapper)
 
         subject.run
         ::ActiveSupport.run_load_hooks(:action_controller, ::ActionController)
@@ -73,52 +75,52 @@ describe ::LogStasher::Railtie do
 
   describe 'config.after_initialize' do
     context 'when logstasher is enabled' do
-      before { ::LogStasher.stub(:enabled?) { true } }
+      before { allow(::LogStasher).to receive(:enabled?) { true } }
 
       context 'and silence_standard_logging is enabled' do
-        before { ::LogStasher.stub(:silence_standard_logging?) { true } }
+        before { allow(::LogStasher).to receive(:silence_standard_logging?) { true } }
 
         it 'should not silence standard logging' do
-          ::ActionController::LogSubscriber.should_receive(:include).with(::LogStasher::SilentLogger)
-          ::ActionView::LogSubscriber.should_receive(:include).with(::LogStasher::SilentLogger)
-          ::Rails::Rack::Logger.should_receive(:include).with(::LogStasher::SilentLogger)
+          expect(::ActionController::LogSubscriber).to receive(:include).with(::LogStasher::SilentLogger)
+          expect(::ActionView::LogSubscriber).to receive(:include).with(::LogStasher::SilentLogger)
+          expect(::Rails::Rack::Logger).to receive(:include).with(::LogStasher::SilentLogger)
           ::ActiveSupport.run_load_hooks(:after_initialize, ::LogStasher::RailtieApp)
         end
       end
 
       context 'and silence_standard_logging is disabled' do
-        before { ::LogStasher.stub(:silence_standard_logging?) { false } }
+        before { allow(::LogStasher).to receive(:silence_standard_logging?) { false } }
 
         it 'should not silence standard logging' do
-          ::ActionController.should_not_receive(:include).with(::LogStasher::SilentLogger)
-          ::ActionView.should_not_receive(:include).with(::LogStasher::SilentLogger)
-          ::Rails::Rack::Logger.should_not_receive(:include).with(::LogStasher::SilentLogger)
+          expect(::ActionController).not_to receive(:include).with(::LogStasher::SilentLogger)
+          expect(::ActionView).not_to receive(:include).with(::LogStasher::SilentLogger)
+          expect(::Rails::Rack::Logger).not_to receive(:include).with(::LogStasher::SilentLogger)
           ::ActiveSupport.run_load_hooks(:after_initialize, ::LogStasher::RailtieApp)
         end
       end
     end
 
     context 'when logstasher is disabled' do
-      before { ::LogStasher.stub(:enabled?) { false } }
+      before { allow(::LogStasher).to receive(:enabled?) { false } }
 
       context 'and silence_standard_logging is enabled' do
-        before { ::LogStasher.stub(:silence_standard_logging?) { true } }
+        before { allow(::LogStasher).to receive(:silence_standard_logging?) { true } }
 
         it 'should not silence standard logging' do
-          ::ActionController::LogSubscriber.should_not_receive(:include).with(::LogStasher::SilentLogger)
-          ::ActionView::LogSubscriber.should_not_receive(:include).with(::LogStasher::SilentLogger)
-          ::Rails::Rack::Logger.should_not_receive(:include).with(::LogStasher::SilentLogger)
+          expect(::ActionController::LogSubscriber).not_to receive(:include).with(::LogStasher::SilentLogger)
+          expect(::ActionView::LogSubscriber).not_to receive(:include).with(::LogStasher::SilentLogger)
+          expect(::Rails::Rack::Logger).not_to receive(:include).with(::LogStasher::SilentLogger)
           ::ActiveSupport.run_load_hooks(:after_initialize, ::LogStasher::RailtieApp)
         end
       end
 
       context 'and silence_standard_logging is disabled' do
-        before { ::LogStasher.stub(:silence_standard_logging?) { false } }
+        before { allow(::LogStasher).to receive(:silence_standard_logging?) { false } }
 
         it 'should not silence standard logging' do
-          ::ActionController.should_not_receive(:include).with(::LogStasher::SilentLogger)
-          ::ActionView.should_not_receive(:include).with(::LogStasher::SilentLogger)
-          ::Rails::Rack::Logger.should_not_receive(:include).with(::LogStasher::SilentLogger)
+          expect(::ActionController).not_to receive(:include).with(::LogStasher::SilentLogger)
+          expect(::ActionView).not_to receive(:include).with(::LogStasher::SilentLogger)
+          expect(::Rails::Rack::Logger).not_to receive(:include).with(::LogStasher::SilentLogger)
           ::ActiveSupport.run_load_hooks(:after_initialize, ::LogStasher::RailtieApp)
         end
       end

--- a/spec/lib/logstasher_spec.rb
+++ b/spec/lib/logstasher_spec.rb
@@ -2,17 +2,17 @@ require 'spec_helper'
 
 describe LogStasher do
   it 'has a version' do
-    ::LogStasher::VERSION.should_not be_nil
+    expect(::LogStasher::VERSION).not_to be_nil
   end
 
   it 'has a logger' do
-    ::LogStasher.logger.should be_a_kind_of(::Logger)
+    expect(::LogStasher.logger).to be_a_kind_of(::Logger)
   end
 
   it 'stores a callback for appending fields' do
     callback = proc { |fields| fail 'Did not expect this to run'  }
 
     ::LogStasher.append_fields(&callback)
-    ::LogStasher.append_fields_callback.should be callback
+    expect(::LogStasher.append_fields_callback).to be callback
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,5 @@ Bundler.require(:default, :development, :test)
 require 'logstasher'
 
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
-  config.filter_run :focus
 end


### PR DESCRIPTION
By default, LogStasher serializes parameters as a JSON string. This is
done to ensure that elasticsearch can index params from different
applications without risk of collisions from params that are named the
same but typed differently.

This adds an option to disable this behavior by setting
`::LogStasher.serialize_parameters = false`. When set to `false` the
parameters will be sent unserialized so that they can be indexed
individually by elasticsearch.

Most of the spec changes were made to remove deprecation from
the latest rspec.

---

RFC @abrandoned @liveh2o 
