### PR TITLE
Remove mutex from syslog device

### DIFF
--- a/lib/logstasher/device/redis.rb
+++ b/lib/logstasher/device/redis.rb
@@ -59,7 +59,7 @@ module LogStasher
 
       def validate_options
         unless ['list', 'channel'].include?(options['data_type'])
-          fail 'Expected data_type to be either "list" or "channel"'
+          fail RuntimeError, 'Expected data_type to be either "list" or "channel"'
         end
       end
     end

--- a/spec/lib/logstasher/device/redis_spec.rb
+++ b/spec/lib/logstasher/device/redis_spec.rb
@@ -40,7 +40,7 @@ describe LogStasher::Device::Redis do
   it 'does not allow unsupported data types' do
     expect {
       device = LogStasher::Device::Redis.new(data_type: 'blargh')
-    }.to raise_error()
+    }.to raise_error(::RuntimeError)
   end
 
   it 'quits the redis connection on #close' do

--- a/spec/lib/logstasher/railtie_spec.rb
+++ b/spec/lib/logstasher/railtie_spec.rb
@@ -19,12 +19,6 @@ describe ::LogStasher::Railtie do
   let(:config) { described_class.config.logstasher }
 
   describe 'logstasher.configure' do
-    subject do
-      described_class.instance.initializers.find do |initializer|
-        initializer.name == 'logstasher.configure'
-      end
-    end
-
     it 'should configure LogStasher' do
       config.logger                   = ::Logger.new('/dev/null')
       config.log_level                = "log_level"
@@ -40,7 +34,7 @@ describe ::LogStasher::Railtie do
       expect(::LogStasher).to receive(:logger=).with(config.logger).and_call_original
       expect(config.logger).to receive(:level=).with("log_level")
 
-      subject.run
+      ActiveSupport.run_load_hooks(:before_initialize)
     end
   end
 


### PR DESCRIPTION
The `Syslog` device is already threadsafe, and the additional mutex creates an unnecessary bottleneck.