### PR TITLE
Add a new #log_as_json method to make it easy to log json messages

### DIFF
--- a/lib/logstasher.rb
+++ b/lib/logstasher.rb
@@ -44,6 +44,24 @@ module LogStasher
       end
     end
 
+    def log_as_json(payload, as_logstash_event: false)
+      raise ArgumentError, "Expected a hash value" unless payload.is_a?(::Hash)
+
+      payload = payload.dup
+      payload.merge!(:metadata => metadata) unless metadata&.empty?
+
+      # Wrap the hash in a logstash event if the caller wishes for a specific
+      # formatting applied to the hash. This is used by log subscriber, for
+      # example.
+      json_payload = if as_logstash_event
+                       ::LogStash::Event.new(payload).to_json
+                     else
+                       payload.to_json
+                     end
+
+      logger << json_payload + $INPUT_RECORD_SEPARATOR
+    end
+
     def logger
       @logger ||= initialize_logger
     end

--- a/lib/logstasher.rb
+++ b/lib/logstasher.rb
@@ -45,10 +45,8 @@ module LogStasher
     end
 
     def log_as_json(payload, as_logstash_event: false)
-      raise ArgumentError, "Expected a hash value" unless payload.is_a?(::Hash)
-
       payload = payload.dup
-      payload.merge!(:metadata => metadata) unless metadata&.empty?
+      payload.merge!(:metadata => metadata) if !metadata&.empty? && payload.is_a?(::Hash)
 
       # Wrap the hash in a logstash event if the caller wishes for a specific
       # formatting applied to the hash. This is used by log subscriber, for

--- a/lib/logstasher/log_subscriber.rb
+++ b/lib/logstasher/log_subscriber.rb
@@ -28,9 +28,7 @@ module LogStasher
       fields.merge! extract_parameters(payload)
       fields.merge! appended_fields
 
-      event = LogStash::Event.new(fields.merge('tags' => tags))
-
-      LogStasher.logger << event.to_json + "\n"
+      LogStasher.log_as_json(fields.merge('tags' => tags), :as_logstash_event => true)
     end
 
     def redirect_to(event)
@@ -51,7 +49,7 @@ module LogStasher
     end
 
     def extract_request(payload)
-      result = {
+      {
         :action     => payload[:action],
         :controller => payload[:controller],
         :format     => extract_format(payload),
@@ -61,9 +59,6 @@ module LogStasher
         :path       => extract_path(payload),
         :route      => "#{payload[:controller]}##{payload[:action]}"
       }
-      metadata = ::LogStasher.metadata
-      result.merge!(:metadata => metadata) unless metadata&.empty?
-      result
     end
 
     # Monkey patching to enable exception logging

--- a/spec/lib/logstasher/log_subscriber_spec.rb
+++ b/spec/lib/logstasher/log_subscriber_spec.rb
@@ -57,8 +57,10 @@ describe LogStasher::LogSubscriber do
 
     let(:event) { double(:payload => payload, :duration => duration) }
 
+    before { ::LogStasher.metadata = data }
+    after { ::LogStasher.metadata = {} }
+
     it 'logs the event in logstash format' do
-      ::LogStasher.metadata = data
       expect(logger).to receive(:<<) do |json|
         expect(JSON.parse(json)).to eq({
           '@timestamp' => timestamp,

--- a/spec/lib/logstasher/logstasher_spec.rb
+++ b/spec/lib/logstasher/logstasher_spec.rb
@@ -1,0 +1,40 @@
+require "spec_helper"
+
+describe ::LogStasher do
+  describe "#log_as_json" do
+    it "calls the logger with the payload" do
+      expect(::LogStasher.logger).to receive(:<<) do |json|
+        expect(::JSON.parse(json)).to eq("yolo" => "brolo")
+      end
+
+      ::LogStasher.log_as_json(:yolo => :brolo)
+    end
+
+    context "with event" do
+      it "calls logger with a logstash event" do
+        expect(::LogStasher.logger).to receive(:<<) do |json|
+          payload = ::JSON.parse(json)
+
+          expect(payload["@timestamp"]).to_not be_nil
+          expect(payload["@version"]).to eq("1")
+          expect(payload["yolo"]).to eq("brolo")
+        end
+
+        ::LogStasher.log_as_json({:yolo => :brolo}, :as_logstash_event => true)
+      end
+    end
+
+    context "with metadata" do
+      before { ::LogStasher.metadata = { :namespace => :cooldude } }
+      after { ::LogStasher.metadata = {} }
+
+      it "calls logger with the metadata" do
+        expect(::LogStasher.logger).to receive(:<<) do |json|
+          expect(::JSON.parse(json)).to eq("yolo" => "brolo", "metadata" => { "namespace" => "cooldude" })
+        end
+
+        ::LogStasher.log_as_json(:yolo => :brolo)
+      end
+    end
+  end
+end

--- a/spec/lib/logstasher/logstasher_spec.rb
+++ b/spec/lib/logstasher/logstasher_spec.rb
@@ -35,6 +35,14 @@ describe ::LogStasher do
 
         ::LogStasher.log_as_json(:yolo => :brolo)
       end
+
+      it "does not merge metadata on an array" do
+        expect(::LogStasher.logger).to receive(:<<) do |json|
+          expect(::JSON.parse(json)).to eq([{ "yolo" => "brolo" }])
+        end
+
+        ::LogStasher.log_as_json([{:yolo => :brolo}])
+      end
     end
   end
 end


### PR DESCRIPTION
If you set LogStasher.metadata, it will be appended to the message with
a :metadata field before calling #to_json.

You can also supply a :as_logstash_event if you wish for your payload to
be wrapped in a LogStash::Event class that adds version and timestamp
fields ready to be consumed by logstash/ elasticsearch.

With this, we were able to clean up the log_subscriber code.