### PR TITLE
logstasher: add option to not touch log file.

### DIFF
--- a/lib/logstasher/railtie.rb
+++ b/lib/logstasher/railtie.rb
@@ -5,6 +5,7 @@ module LogStasher
     config.logstasher.include_parameters = true
     config.logstasher.serialize_parameters = true
     config.logstasher.silence_standard_logging = false
+    config.logstasher.silence_creation_message = true
     config.logstasher.logger = nil
     config.logstasher.log_level = ::Logger::INFO
 
@@ -49,7 +50,9 @@ module LogStasher
     def default_logger
       unless @default_logger
         path = ::Rails.root.join('log', "logstash_#{::Rails.env}.log")
-        ::FileUtils.touch(path) # prevent autocreate messages in log
+        if config.logstasher.silence_creation_message
+          ::FileUtils.touch(path) # prevent autocreate messages in log
+        end
 
         @default_logger =  ::Logger.new(path)
       end

--- a/spec/lib/logstasher/railtie_spec.rb
+++ b/spec/lib/logstasher/railtie_spec.rb
@@ -26,8 +26,10 @@ describe ::LogStasher::Railtie do
   end
 
   describe 'logstasher should NOT touch log file if silence disabled' do
+    before { config.silence_creation_message = false }
+    after { config.silence_creation_message = true }
+
     it 'should configure LogStasher' do
-      config.silence_creation_message = false
       expect(::FileUtils).not_to receive(:touch)
       ActiveSupport.run_load_hooks(:before_initialize)
     end

--- a/spec/lib/logstasher/railtie_spec.rb
+++ b/spec/lib/logstasher/railtie_spec.rb
@@ -18,6 +18,23 @@ end
 describe ::LogStasher::Railtie do
   let(:config) { described_class.config.logstasher }
 
+  describe 'logstasher should touch log file to prevent meessage by default' do
+    it 'should configure LogStasher' do
+      config.silence_creation_message = true
+      expect(::FileUtils).to receive(:touch)
+      ActiveSupport.run_load_hooks(:before_initialize)
+    end
+  end
+
+  describe 'logstasher should NOT touch log file if silence disabled' do
+    it 'should configure LogStasher' do
+      config.silence_creation_message = false
+      expect(::FileUtils).not_to receive(:touch)
+      ActiveSupport.run_load_hooks(:before_initialize)
+    end
+  end
+
+
   describe 'logstasher.configure' do
     it 'should configure LogStasher' do
       config.logger                   = ::Logger.new('/dev/null')

--- a/spec/lib/logstasher/railtie_spec.rb
+++ b/spec/lib/logstasher/railtie_spec.rb
@@ -18,9 +18,8 @@ end
 describe ::LogStasher::Railtie do
   let(:config) { described_class.config.logstasher }
 
-  describe 'logstasher should touch log file to prevent meessage by default' do
+  describe 'logstasher should touch log file to prevent creation message by default' do
     it 'should configure LogStasher' do
-      config.silence_creation_message = true
       expect(::FileUtils).to receive(:touch)
       ActiveSupport.run_load_hooks(:before_initialize)
     end


### PR DESCRIPTION
adds an initialization option `silence_creation_message` that will prevent the file touch to the rails log file from happening. This is to stop errors when trying to write to a read-only container.