### PR TITLE
Merge metadata into LogStash::Event types

### DIFF
--- a/spec/lib/logstasher/logstasher_spec.rb
+++ b/spec/lib/logstasher/logstasher_spec.rb
@@ -36,6 +36,14 @@ describe ::LogStasher do
         ::LogStasher.log_as_json(:yolo => :brolo)
       end
 
+      it "merges metadata for LogStash::Event types" do
+        expect(::LogStasher.logger).to receive(:<<) do |json|
+          expect(::JSON.parse(json)).to match(a_hash_including("yolo" => "brolo", "metadata" => { "namespace" => "cooldude" }))
+        end
+
+        ::LogStasher.log_as_json(::LogStash::Event.new(:yolo => :brolo))
+      end
+
       it "does not merge metadata on an array" do
         expect(::LogStasher.logger).to receive(:<<) do |json|
           expect(::JSON.parse(json)).to eq([{ "yolo" => "brolo" }])


### PR DESCRIPTION
We're already doing this wish hashes, but we should also be appending metadata to LogStash::Events as well.