### PR TITLE
Format dry-validation payload

### DIFF
--- a/lib/logstasher.rb
+++ b/lib/logstasher.rb
@@ -119,15 +119,15 @@ module LogStasher
     def validate_payload(payload)
       return unless payload.is_a?(::LogStash::Event) || payload.is_a?(::Hash)
 
-      validation = dry_validation_contract.call(payload.to_hash)
-
+      formatted_payload = ::JSON.parse(payload.to_json).deep_symbolize_keys
+      validation = dry_validation_contract.call(formatted_payload)
       validation_payload = {
         dry_validation_success: validation.success?,
         dry_validation_errors: validation.errors.to_h.to_json
       }
 
       return payload.append(validation_payload) if payload.is_a?(::LogStash::Event)
-      return payload.deep_merge!(validation_payload) if payload.is_a?(::Hash)
+      return payload.merge!(validation_payload) if payload.is_a?(::Hash)
     end
   end
 end

--- a/lib/logstasher/version.rb
+++ b/lib/logstasher/version.rb
@@ -1,3 +1,3 @@
 module LogStasher
-  VERSION = "1.9.0"
+  VERSION = "1.9.1"
 end

--- a/spec/lib/logstasher/logstasher_spec.rb
+++ b/spec/lib/logstasher/logstasher_spec.rb
@@ -134,6 +134,18 @@ describe ::LogStasher do
 
         ::LogStasher.log_as_json([{"yolo" => "brolo"}])
       end
+
+      it "formats the payload correctly for the contract call" do
+        expect(::LogStasher.logger).to receive(:<<) do |json|
+          payload = ::JSON.parse(json)
+          expect(payload["dry_validation_errors"]).to eq("{}")
+          expect(payload["dry_validation_success"]).to be true
+          expect(payload["yolo"]).to eq("brolo")
+          expect(payload["metadata"]["namespace"]).to eq("cooldude")
+        end
+
+        ::LogStasher.log_as_json(::LogStash::Event.new("yolo" => :brolo))
+      end
     end
   end
 


### PR DESCRIPTION
Formats the dry-validation payload with symbolized keys and .to_json values. Also corrects .deep_merge! call to .merge!