### PR TITLE
Add support for type coercion

### DIFF
--- a/lib/logstasher/version.rb
+++ b/lib/logstasher/version.rb
@@ -1,3 +1,3 @@
 module LogStasher
-  VERSION = "1.9.1"
+  VERSION = "1.9.2"
 end


### PR DESCRIPTION
Allows for type coercion via the dry-validation contract if defined.